### PR TITLE
fix link to setup-config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ python setup.py
 
 ### Install config.
 
-See [seup-config.yml](/config/setup-config.yml) details.
+See [seup-config.yaml](/config/setup-config.yaml) details.
 
 you can customize these settings.
 


### PR DESCRIPTION
# Description
<!-- Please write short description of the this Pull Request changes. -->
- ROOTのREADMEからリンクさせているsetup-config.yamlへのリンクパスが誤っており404リクエストになってしまっていた為、正しいリンクパスへ修正

# Linked issues
<!--Please write linked issues number. -->
- #41 

# Tests
<!--Please write down ths tests you did for this Pull Request. -->
- README内のsetup-config.yamlへのリンクパスが正しいパスになっていること
