### PR TITLE
refactoring setup.py and test_setup.py

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,8 @@ phases:
   install:
     runtime-versions:
       python: 3.8
+    commands:
+      - pip install parameterized
 
   build:
     commands:

--- a/tests/config/setup-config.yaml
+++ b/tests/config/setup-config.yaml
@@ -1,0 +1,14 @@
+setup:
+  config_file:
+    file_path: "$HOME/.aws/config"
+
+  register_profile:
+    profile_name:
+      default: "sts-session"
+    region:
+      default: "ap-northeast-1"
+    output:
+      default: "json"
+
+  change_log:
+    file_path: "$HOME/.aws/sts_assumed_role.log"

--- a/tests/template/register_sts_assumed_role.test.tmpl
+++ b/tests/template/register_sts_assumed_role.test.tmpl
@@ -1,0 +1,183 @@
+###### register_sts_assumed_role starts here ######
+function __backup_original_config {
+  cp ${1} "${1}_bk_$(date "+%Y%m%d%H%M%S")"
+}
+
+function __generate_register_profile_for_config_file {
+  register_profile=${1}
+  role_arn=${2}
+  source_profile=${3}
+  region_name=${4}
+  output_format=${5}
+  mfa_serial=${6}
+  
+  generated_profile="\n"
+  if [ "${register_profile}" = "default" ]; then
+    generated_profile+="[default]\n"
+  else
+    generated_profile+="[profile ${register_profile}]\n"
+  fi
+  generated_profile+="role_arn = ${role_arn}\n"
+  generated_profile+="source_profile = ${source_profile}\n"
+  if [ "${mfa_serial}" != "" ]; then
+    generated_profile+="mfa_serial = ${mfa_serial}\n"
+  fi
+  generated_profile+="region = ${region_name}\n"
+  generated_profile+="output = ${output_format}\n"
+  echo -e "${generated_profile}"
+}
+
+function __insert_assumed_role_delete_log {
+  change_log_file_path=${1}
+  delete_profile_name=${2}
+
+  shift 2
+  for delete_profile in "${@}"; do
+    if [ "${delete_profile:0:8}" = "role_arn" ]; then
+      delete_role_arn=${delete_profile}
+    elif [ "${delete_profile:0:14}" = "source_profile" ]; then
+      delete_source_profile=${delete_profile}
+    elif [ "${delete_profile:0:10}" = "mfa_serial" ]; then
+      delete_mfa_serial=${delete_profile}
+    fi
+  done
+
+  delete_log="DELETED - - [$(LANG="C" date "+%d/%b/%Y:%H:%M:%S %z")] "
+  delete_log+="\"profile = ${delete_profile_name}\" "
+  if [ "${delete_role_arn}" != "" ]; then
+    delete_log+="\"${delete_role_arn}\" "
+  fi
+  if [ "${delete_source_profile}" != "" ]; then
+    delete_log+="\"${delete_source_profile}\" "
+  fi
+  if [ "${delete_mfa_serial}" != "" ]; then
+    delete_log+="\"${delete_mfa_serial}\" "
+  fi
+  delete_log+="\n"
+
+  echo -e "${delete_log}" >> ${change_log_file_path}
+}
+
+function __insert_assumed_role_register_log {
+  change_log_file_path=${1}
+  register_profile=${2}
+  role_arn=${3}
+  source_profile=${4}
+  mfa_serial=${5}
+
+  comment=""
+  read -p "Enter a comment when you register [${register_profile}]: " comment
+  if [ "${comment}" = "" ]; then
+    comment="None"
+  fi
+
+  register_log="REGISTERED - - [$(LANG="C" date "+%d/%b/%Y:%H:%M:%S %z")] "
+  register_log+="\"profile = ${register_profile}\" "
+  register_log+="\"role_arn = ${role_arn}\" "
+  register_log+="\"source_profile = ${source_profile}\" "
+  if [ "${mfa_serial}" != "" ]; then
+    register_log+="\"mfa_serial = ${mfa_serial}\" "
+  fi
+  register_log+="\"registered comment = ${comment}\"\n"
+
+  echo -e "${register_log}" >> ${change_log_file_path}
+}
+
+function register_sts_assumed_role {
+  #
+  # Const value.
+  #
+  CONFIG_FILE_PATH=$REPLACEMENT_STRING_CONFIG_FILE_PATH # set from setup.py
+  REGISTER_PROFILE=$REPLACEMENT_STRING_REGISTER_PROFILE # set from setup.py
+  REGION_NAME=$REPLACEMENT_STRING_REGION_NAME # set from setup.py
+  OUTPUT_FORMAT=$REPLACEMENT_STRING_OUTPUT_FORMAT # set from setup.py
+  CHANGE_LOG_FILE_PATH=$REPLACEMENT_STRING_CHANGE_LOG_FILE_PATH # set from setup.py
+  
+  #
+  # User input(Required).
+  #
+  ROLE_ARN=""
+  while [ "${ROLE_ARN}" = "" ]; do
+    read -p "ASSUMED ROLE ARN [None]: " ROLE_ARN
+  done
+  SOURCE_PROFILE=""
+  while [ "${SOURCE_PROFILE}" = "" ]; do
+    read -p "SOURCE PROFILE NAME [None]: " SOURCE_PROFILE
+  done
+
+  #
+  # User input(Optional).
+  #
+  override_register_profile=""
+  read -p "REGISTER PROFILE NAME [${REGISTER_PROFILE}]: " override_register_profile
+  if [ "${override_register_profile}" != "" ]; then
+    REGISTER_PROFILE=${override_register_profile}
+  fi
+  MFA_SERIAL=""
+  read -p "MFA SERIAL ARN [None]: " MFA_SERIAL
+  override_region_name=""
+  read -p "Default region name [${REGION_NAME}]: " override_region_name
+  if [ "${override_region_name}" != "" ]; then
+    REGION_NAME=${override_region_name}
+  fi
+  override_output_format=""
+  read -p "Default output format [${OUTPUT_FORMAT}]: " override_output_format
+  if [ "${override_output_format}" != "" ]; then
+    OUTPUT_FORMAT=${override_output_format}
+  fi
+
+  __backup_original_config ${CONFIG_FILE_PATH}
+
+  #
+  # Create overwrite config detail.
+  #
+  overwrite_config=""
+  is_delete_profile=false
+  declare -a delete_profile=()
+  while read line || [ -n "${line}" ]; do
+    if [ "${line}" = "" ]; then
+      continue
+    fi
+
+    if [ "${line}" = "[profile ${REGISTER_PROFILE}]" ] || [ "${line}" = "[${REGISTER_PROFILE}]" ]; then
+      delete_profile=("${delete_profile[@]}" "${line}")
+      is_delete_profile=true
+      continue
+    fi
+
+    if "${is_delete_profile}"; then
+      if [ "${line:0:8}" = "[profile" ] || [ "${line:0:9}" = "[default]" ]; then
+        is_delete_profile=false
+      else
+        delete_profile=("${delete_profile[@]}" "${line}")
+        continue
+      fi
+    fi
+
+    if [ "${line:0:8}" = "[profile" ] || [ "${line:0:9}" = "[default]" ]; then
+      if [ "${overwrite_config}" != "" ]; then
+        overwrite_config+="\n"
+      fi
+    fi
+
+    overwrite_config+="${line}\n"
+  done<${CONFIG_FILE_PATH}
+
+  overwrite_config+=`__generate_register_profile_for_config_file ${REGISTER_PROFILE} ${ROLE_ARN} ${SOURCE_PROFILE} ${REGION_NAME} ${OUTPUT_FORMAT} ${MFA_SERIAL}`
+
+  #
+  # Overwrite config file.
+  #
+  echo -e "${overwrite_config}" > ${CONFIG_FILE_PATH}
+  
+  #
+  # Insert change log.
+  #
+  if [ -n "$delete_profile" ]; then
+    __insert_assumed_role_delete_log ${CHANGE_LOG_FILE_PATH} ${REGISTER_PROFILE} "${delete_profile[@]}"
+  fi
+  __insert_assumed_role_register_log ${CHANGE_LOG_FILE_PATH} ${REGISTER_PROFILE} ${ROLE_ARN} ${SOURCE_PROFILE} ${MFA_SERIAL}
+
+  echo "register_sts_assumed_role DONE!"
+}
+###### register_sts_assumed_role ends here ######


### PR DESCRIPTION
# Description

<!-- Please write short description of the this Pull Request changes. -->
- setup.pyの各メソッドの責務範囲を適正化
  - load_setup_configで読み込むファイルパスはメソッド内で指定するように（外から渡したファイルパスを読み込む形を廃止）
  - exist_register_sts_assumed_roleのstart_signalとend_signalはメソッド内で指定するように（外から渡した文字列をシグナルとして使用する形を廃止）
- 不要なメソッド（enabling_register_sts_assumed_role）を削除
- テスト用に使用するログインシェル設定ファイルのファイルパスを定数化
- テスト用のログインシェルで使用するregister_sts_assumed_role関数のテンプレートファイルを新規作成（BASH用のテンプレートファイルをテストでも使い回すのを廃止）
- テスト用のsetup-config.yamlファイルを新規作成（実際のスクリプト実行時とテストで同一のsetup-config.yamlファイルを使い回すのを廃止）
- テストでパターン別の期待値テストにparameterizedを使うように変更（テストメソッド内でループを回しながらテストする方法を廃止）
- テスト実行時に作成したtmpファイルの削除タイミングをテスト終了時（unittest.tearDownClass）に一括で削除するように修正

# Linked issues
<!--Please write linked issues number. -->
- #34 

# Tests
<!--Please write down ths tests you did for this Pull Request. -->
- CodeBuildのビルドタスク実行時にparameterizedがpip経由でインストールできること
- 全てのテストが通り、今回の変更前と変更後でsetup.py実行時の挙動に変化がないこと
- 全てのテストが通り、また、setup.pyで実行される内容に対してのテストカバレッジ（C0/C1/C2）が変更前から減少していないこと